### PR TITLE
Use local DB in Scaleway

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Docker compose down on VPS
         run: ssh root@${{ vars.VPS_IP }} docker compose --project-directory app down
       - name: Docker compose up on VPS
-        run: ssh root@${{ vars.VPS_IP }} TAG="${{ env.TAG }}" DATABASE_URL="${{ secrets.DATABASE_URL }}" SESSION_KEY="${{ secrets.SESSION_KEY }}" OAUTH_CLIENT_SECRET="${{ secrets.OAUTH_CLIENT_SECRET }}" OAUTH_CLIENT_ID="${{ vars.OAUTH_CLIENT_ID }}" docker compose --project-directory app up --wait
+        run: ssh root@${{ vars.VPS_IP }} TAG="${{ env.TAG }}" DB_PWD="${{ secrets.DB_PWD }}" SESSION_KEY="${{ secrets.SESSION_KEY }}" OAUTH_CLIENT_SECRET="${{ secrets.OAUTH_CLIENT_SECRET }}" OAUTH_CLIENT_ID="${{ vars.OAUTH_CLIENT_ID }}" ODOO_API_KEY="${{ secrets.ODOO_API_KEY }}" docker compose --project-directory app up --wait
       - name: Docker logout on VPS
         run: ssh root@${{ vars.VPS_IP }} docker logout ghcr.io
         continue-on-error: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,10 @@ COPY Cargo.toml Cargo.lock ./
 COPY build.rs build.rs ./
 COPY src/ src/
 COPY .sqlx .sqlx/
+COPY migrations migrations/
 
 # Don't depend on live sqlx during build use cached .sqlx
-RUN SQLX_OFFLINE=true cargo build --release --bin app
+RUN SQLX_OFFLINE=true cargo build --release --bin app --features load-fixtures
 
 FROM debian:bookworm-slim AS final
 RUN apt-get update && apt-get install libssl3 -y && apt-get upgrade -y

--- a/docker-compose.vps.yml
+++ b/docker-compose.vps.yml
@@ -14,11 +14,15 @@ services:
       SMTP_SERVER_NAME: "remails-dev.tweedegolf-test.nl"
       SMTP_CERT_FILE: "/home/nonroot/cert.pem"
       SMTP_KEY_FILE: "/home/nonroot/key.pem"
-      DATABASE_URL: "${DATABASE_URL}"
-      REDIRECT_URL: "https://remails-dev.tweedegolf-test.nl/api/authorize"
+      DATABASE_URL: "postgres://remails:${DB_PWD}@postgres:5432/remails"
+      GITHUB_OAUTH_REDIRECT_URL: "https://remails-dev.tweedegolf-test.nl/api/oauth/authorize/github"
       SESSION_KEY: "${SESSION_KEY}"
       OAUTH_CLIENT_ID: "${OAUTH_CLIENT_ID}"
       OAUTH_CLIENT_SECRET: "${OAUTH_CLIENT_SECRET}"
+      ODOO_BASE_URL: "https://staging-remails.odoo.com/jsonrpc"
+      ODOO_DATABASE_NAME: "remails-16-0-sandbox-19290361"
+      ODOO_USER_ID: "21"
+      ODOO_API_KEY: "${ODOO_API_KEY}"
 
   caddy:
     image: caddy
@@ -30,6 +34,17 @@ services:
       - ./caddy:/etc/caddy
       - caddy_data:/data
       - caddy_config:/config
+
+  postgres:
+    image: postgres
+    volumes:
+      - "./postgres-data:/var/lib/postgresql/data"
+    environment:
+      POSTGRES_USER: remails
+      POSTGRES_PASSWORD: ${DB_PWD}
+      POSTGRES_DB: remails
+    ports:
+      - "5432:5432"
 
 volumes:
   caddy_data:


### PR DESCRIPTION
This simplifies the dev deployment in that we do not use a managed DB instance anymore but use docker compose to run a DB locally on our dev machine.