### PR TITLE
Add cargo deny exception for `rustls-pemfile`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -27,4 +27,5 @@ private = { ignore = true }
 [advisories]
 ignore = [
     { id = "RUSTSEC-2024-0436", reason = "utoipa-axum did not provide an updated version yet. Please take a look at https://github.com/juhaku/utoipa/pull/1483" },
+    { id = "RUSTSEC-2025-0134", reason = "https://github.com/stalwartlabs/mail-auth/issues/48" }
 ]


### PR DESCRIPTION
After https://github.com/stalwartlabs/mail-auth/issues/48 got resolved, we should remove the exception again